### PR TITLE
Fix bot moving to limbo correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypixel-discord-chat-bridge",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "A Hypixel guild chat and Discord chat bridge",
   "main": "index.js",
   "scripts": {

--- a/src/minecraft/handlers/ChatHandler.js
+++ b/src/minecraft/handlers/ChatHandler.js
@@ -21,7 +21,7 @@ class StateHandler extends EventHandler {
     if (this.isLobbyJoinMessage(message)) {
       console.log('Sending Minecraft client to limbo')
 
-      return this.bot.chat('/limbo')
+      return this.bot.chat('§')
     }
 
     if (!this.isGuildMessage(message)) {


### PR DESCRIPTION
The limbo command doesn't really do anything when being used from Mineflayer for some reason, however sending `§` as a message does move the bot to a limbo server, so now it does this instead. 🤷 