### PR TITLE
Choose which account type to use in config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The server is the server the Minecraft client should connect to, by default it w
 
 #### Minecraft
 
-The minecraft section includes a `username` and `password` option, these should be filled out with your Mojang username and password for the Minecraft account you plan on using, your Minecraft username is most likely the email it was created with. There is also a `lobbyHolder` option which is used in the `!guildlobby` command, this command will whisper the user specified in the config with a message using the `?tw <username>` format, for this command to do anything another bot needs to listen, and then act when receiving the message. 
+The minecraft section includes a `username` and `password` option, if using a Mojang account these should be filled out with your Mojang username and password for the Minecraft account you plan on using, your Minecraft username is most likely the email it was created with. If using with a microsoft account change `accountType` to `microsoft`, `username` and `password` are not required and will be left blank as you will be directed to the [Microsoft Link page]( https://www.microsoft.com/link). There is also a `lobbyHolder` option which is used in the `!guildlobby` command, this command will whisper the user specified in the config with a message using the `?tw <username>` format, for this command to do anything another bot needs to listen, and then act when receiving the message. 
 
 #### Discord
 

--- a/config.example.json
+++ b/config.example.json
@@ -6,7 +6,8 @@
   "minecraft": {
     "username": "yourUsername",
     "password": "yourPassword",
-    "lobbyHolder": "ignUsername"
+    "lobbyHolder": "ignUsername",
+    "accountType": "mojang"
   },
   "discord": {
     "token": "discordBotToken",

--- a/src/minecraft/MinecraftManager.js
+++ b/src/minecraft/MinecraftManager.js
@@ -32,7 +32,7 @@ class MinecraftManager extends CommunicationBridge {
       username: config.minecraft.username,
       password: config.minecraft.password,
       version: false,
-      auth: 'mojang',
+      auth: config.minecraft.accountType,
     })
   }
 


### PR DESCRIPTION
Updated `MinecraftManager.js` to reference a new `accountType` field in `MinecraftManager.js` to make it easier to use with a microsoft account. Updated the readme with information about how to use microsoft account.