### PR TITLE
Changed override permissions, only minecraft account owner can use

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -13,6 +13,7 @@
     "token": "discordBotToken",
     "channel": "channelId",
     "commandRole": "roleId",
+    "ownerId": "ownerId",
     "prefix": "!"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypixel-discord-chat-bridge",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "A Hypixel guild chat and Discord chat bridge",
   "main": "index.js",
   "scripts": {

--- a/src/discord/commands/CommandHandler.js
+++ b/src/discord/commands/CommandHandler.js
@@ -70,7 +70,7 @@ class CommandHandler {
     } else if ((message.content.startsWith(`${prefix}o`) || (message.content.startsWith(`${prefix}override`))) && !this.isOwner(message.member)){
       return message.reply("You're not allowed to run this command!")
     } else if((message.content.startsWith(`${prefix}o`) || (message.content.startsWith(`${prefix}override`))) && this.isOwner(message.member)){
-      return command.handle.onCommand(message)
+      return command.handler.onCommand(message)
     } else if (!this.isCommander(message.member)) {
       return message.reply("You're not allowed to run this command!")
     }

--- a/src/discord/commands/CommandHandler.js
+++ b/src/discord/commands/CommandHandler.js
@@ -67,15 +67,18 @@ class CommandHandler {
   runCommand(command, message) {
     if (message.content == `${prefix}h` || message.content == `${prefix}help`) {
       return command.handler.onCommand(message)
-    } else if ((message.content.startsWith(`${prefix}o`) || (message.content.startsWith(`${prefix}override`))) && !this.isOwner(message.member)){
+    }
+
+    if (!this.isCommander(message.member)) {
       return message.reply("You're not allowed to run this command!")
-    } else if((message.content.startsWith(`${prefix}o`) || (message.content.startsWith(`${prefix}override`))) && this.isOwner(message.member)){
-      return command.handler.onCommand(message)
-    } else if (!this.isCommander(message.member)) {
+    }
+
+    if (command.handler.constructor.name == 'OverrideCommand' && !this.isOwner(message.member)) {
       return message.reply("You're not allowed to run this command!")
     }
 
     console.log(`Discord Command Handler > [${command.handler.constructor.name}] ${message.content}`)
+
     command.handler.onCommand(message)
   }
 

--- a/src/discord/commands/CommandHandler.js
+++ b/src/discord/commands/CommandHandler.js
@@ -67,17 +67,24 @@ class CommandHandler {
   runCommand(command, message) {
     if (message.content == `${prefix}h` || message.content == `${prefix}help`) {
       return command.handler.onCommand(message)
+    } else if ((message.content.startsWith(`${prefix}o`) || (message.content.startsWith(`${prefix}override`))) && !this.isOwner(message.member)){
+      return message.reply("You're not allowed to run this command!")
+    } else if((message.content.startsWith(`${prefix}o`) || (message.content.startsWith(`${prefix}override`))) && this.isOwner(message.member)){
+      return command.handle.onCommand(message)
     } else if (!this.isCommander(message.member)) {
       return message.reply("You're not allowed to run this command!")
     }
 
     console.log(`Discord Command Handler > [${command.handler.constructor.name}] ${message.content}`)
-
     command.handler.onCommand(message)
   }
 
   isCommander(member) {
     return member.roles.cache.find(r => r.id == config.discord.commandRole)
+  }
+
+  isOwner(member) {
+    return member.id == config.discord.ownerId
   }
 }
 

--- a/src/discord/commands/OverrideCommand.js
+++ b/src/discord/commands/OverrideCommand.js
@@ -10,6 +10,7 @@ class OverrideCommand extends DiscordCommand {
     }
 
     this.sendMinecraftMessage(`/${args}`)
+
     message.reply(`\`/${args}\` has been executed`)
   }
 }

--- a/src/discord/commands/OverrideCommand.js
+++ b/src/discord/commands/OverrideCommand.js
@@ -10,7 +10,7 @@ class OverrideCommand extends DiscordCommand {
     }
 
     this.sendMinecraftMessage(`/${args}`)
-    message.reply(`/${args} has been executed`)
+    message.reply(`\`/${args}\` has been executed`)
   }
 }
 


### PR DESCRIPTION
Override could be used in malicious ways to get the bot muted in all chat or banned for boosting:
- Config now has a `ownerId` field, only the specified user can use override commands
- Changed override feedback message to show the command executed in a discord code block