### PR TITLE
Improve Discord message reply name handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypixel-discord-chat-bridge",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "A Hypixel guild chat and Discord chat bridge",
   "main": "index.js",
   "scripts": {

--- a/src/discord/handlers/MessageHandler.js
+++ b/src/discord/handlers/MessageHandler.js
@@ -31,7 +31,7 @@ class MessageHandler {
 
       const reference = await message.channel.messages.fetch(message.reference.messageID)
 
-      return reference.author.username
+      return reference.member.displayName
     } catch (e) {
       return null
     }

--- a/src/discord/handlers/MessageHandler.js
+++ b/src/discord/handlers/MessageHandler.js
@@ -31,7 +31,7 @@ class MessageHandler {
 
       const reference = await message.channel.messages.fetch(message.reference.messageID)
 
-      return reference.member.displayName
+      return reference.member ? reference.member.displayName : reference.author.username
     } catch (e) {
       return null
     }


### PR DESCRIPTION
Previously replies would be prefixed as `${Server Nickname} replying to ${Discord Username}:`, meaning if you were nicked in the server and replied to your own message it would look weird as shown here: ![](https://media.neyoa.me/i/79StIUs)
This replaces the username with the server nick in order to keep the same.

If webhook message mode is enabled replying to the webhook will be displayed as `${Server Nickname} replying to ${Minecraft IGN}` instead of as if there was no reply.