### PR TITLE
Fix failed Discord login attempts stopping the process correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypixel-discord-chat-bridge",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "A Hypixel guild chat and Discord chat bridge",
   "main": "index.js",
   "scripts": {

--- a/src/discord/DiscordManager.js
+++ b/src/discord/DiscordManager.js
@@ -30,6 +30,8 @@ class DiscordManager extends CommunicationBridge {
 
     this.client.login(this.app.config.discord.token).catch(error => {
       console.error('Discord Bot Error: ', error)
+
+      process.exit(1)
     })
 
     process.on('SIGINT', () => this.stateHandler.onClose())

--- a/src/discord/handlers/StateHandler.js
+++ b/src/discord/handlers/StateHandler.js
@@ -31,7 +31,7 @@ class StateHandler {
           color: 'DC143C'
         }
       }).then(() => { process.exit() })
-    })
+    }).catch(process.exit())
   }
 }
 


### PR DESCRIPTION
If an invalid bot token is provided, the bot will not start and attempting to exit it will throw infinite errors about not being able to send the offline message - this ensures the program exits when you stop it even if something goes wrong.