### PR TITLE
Add broadcasts for most guild events

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypixel-discord-chat-bridge",
-  "version": "1.7.4",
+  "version": "1.5.0",
   "description": "A Hypixel guild chat and Discord chat bridge",
   "main": "index.js",
   "scripts": {

--- a/src/contracts/CommunicationBridge.js
+++ b/src/contracts/CommunicationBridge.js
@@ -15,12 +15,16 @@ class CommunicationBridge {
     return this.bridge.onBroadcast(event)
   }
 
-  broadcastLogin(event) {
-    return this.bridge.onLogin(event)
+  broadcastPlayerToggle(event) {
+    return this.bridge.onPlayerToggle(event)
   }
 
-  broadcastLogout(event) {
-    return this.bridge.onLogout(event)
+  broadcastCleanEmbed(event) {
+    return this.bridge.onBroadcastCleanEmbed(event)
+  }
+
+  broadcastHeadedEmbed(event) {
+    return this.bridge.onBroadcastHeadedEmbed(event)
   }
 
   connect() {

--- a/src/discord/DiscordManager.js
+++ b/src/discord/DiscordManager.js
@@ -70,51 +70,48 @@ class DiscordManager extends CommunicationBridge {
     }
   }
 
-  onLogin(username) {
-    this.app.log.broadcast(`${username} joined.`, `Discord`)
-    switch (this.app.config.discord.messageMode.toLowerCase()) {
-      case 'bot':
-        this.app.discord.client.channels.fetch(this.app.config.discord.channel).then(channel => {
-          channel.send({
-            embed: {
-              color: '7CFC00',
-              timestamp: new Date(),
-              author: {
-                name: `${username} joined.`,
-                icon_url: 'https://www.mc-heads.net/avatar/' + username,
-              },
-            }
-          })
-        })
-        break
+  onBroadcastCleanEmbed({ message, color }) {
+    this.app.log.broadcast(message, 'Event')
 
-      case 'webhook':
-        this.app.discord.webhook.send({
-          username: username, avatarURL: 'https://www.mc-heads.net/avatar/' + username, embeds: [{
-            color: '7CFC00',
-            author: {
-              name: `${username} joined.`,
-            },
-          }]
-        })
-        break
-
-      default:
-        throw new Error('Invalid message mode: must be bot or webhook')
-    }
+    this.app.discord.client.channels.fetch(this.app.config.discord.channel).then(channel => {
+      channel.send({
+        embed: {
+          color: color,
+          description: message,
+        }
+      })
+    })
   }
 
-  onLogout(username) {
-    this.app.log.broadcast(`${username} left.`, `Discord`)
+  onBroadcastHeadedEmbed({ message, title, icon, color }) {
+    this.app.log.broadcast(message, 'Event')
+
+    this.app.discord.client.channels.fetch(this.app.config.discord.channel).then(channel => {
+      channel.send({
+        embed: {
+          color: color,
+          author: {
+            name: title,
+            icon_url: icon,
+          },
+          description: message,
+        }
+      })
+    })
+  }
+
+  onPlayerToggle({ username, message, color }) {
+    this.app.log.broadcast(username + ' ' + message, 'Event')
+
     switch (this.app.config.discord.messageMode.toLowerCase()) {
       case 'bot':
         this.app.discord.client.channels.fetch(this.app.config.discord.channel).then(channel => {
           channel.send({
             embed: {
-              color: 'DC143C',
+              color: color,
               timestamp: new Date(),
               author: {
-                name: `${username} left.`,
+                name: `${username} ${message}`,
                 icon_url: 'https://www.mc-heads.net/avatar/' + username,
               },
             }
@@ -125,10 +122,8 @@ class DiscordManager extends CommunicationBridge {
       case 'webhook':
         this.app.discord.webhook.send({
           username: username, avatarURL: 'https://www.mc-heads.net/avatar/' + username, embeds: [{
-            color: 'DC143C',
-            author: {
-              name: `${username} left.`,
-            },
+            color: color,
+            description: `${username} ${message}`,
           }]
         })
         break

--- a/src/discord/commands/DemoteCommand.js
+++ b/src/discord/commands/DemoteCommand.js
@@ -3,15 +3,9 @@ const DiscordCommand = require('../../contracts/DiscordCommand')
 class DemoteCommand extends DiscordCommand {
   onCommand(message) {
     let args = this.getArgs(message)
+    let user = args.shift()
 
-    if (args.length == 0) {
-      return message.reply(`You need to specify a user to demote`)
-    }
-
-    let username = args[0]
-
-    this.sendMinecraftMessage(`/g demote ${username}`)
-    message.reply(`${username} has been demoted`)
+    this.sendMinecraftMessage(`/g demote ${user ? user : ''}`)
   }
 }
 

--- a/src/discord/commands/InviteCommand.js
+++ b/src/discord/commands/InviteCommand.js
@@ -3,15 +3,9 @@ const DiscordCommand = require('../../contracts/DiscordCommand')
 class InviteCommand extends DiscordCommand {
   onCommand(message) {
     let args = this.getArgs(message)
+    let user = args.shift()
 
-    if (args.length == 0) {
-      return message.reply(`You need to specify a user to invite`)
-    }
-
-    let username = args[0]
-
-    this.sendMinecraftMessage(`/g invite ${username}`)
-    message.reply(`${username} has been invited to the guild`)
+    this.sendMinecraftMessage(`/g invite ${user ? user : ''}`)
   }
 }
 

--- a/src/discord/commands/KickCommand.js
+++ b/src/discord/commands/KickCommand.js
@@ -3,18 +3,10 @@ const DiscordCommand = require('../../contracts/DiscordCommand')
 class KickCommand extends DiscordCommand {
   onCommand(message) {
     let args = this.getArgs(message)
+    let user = args.shift()
+    let reason = args.join(' ')
 
-    if (args.length == 0) {
-      return message.reply(`You need to specify a user to kick`)
-    } else if (args.length == 1) {
-      return message.reply(`You need to give a reason for kicking`)
-    }
-
-    let username = args[0]
-    let reason = args.slice(1).join(' ')
-
-    this.sendMinecraftMessage(`/g kick ${username} ${reason}`)
-    message.reply(`${username} has been kicked from the guild for reason ${reason}`)
+    this.sendMinecraftMessage(`/g kick ${user ? user : ''} ${reason ? reason : ''}`)
   }
 }
 

--- a/src/discord/commands/MuteCommand.js
+++ b/src/discord/commands/MuteCommand.js
@@ -3,18 +3,10 @@ const DiscordCommand = require('../../contracts/DiscordCommand')
 class MuteCommand extends DiscordCommand {
   onCommand(message) {
     let args = this.getArgs(message)
+    let user = args.shift()
+    let time = args.shift()
 
-    if (args.length == 0) {
-      return message.reply(`You need to specify a user to mute`)
-    } else if (args.length == 1) {
-      return message.reply(`You need to give a time to mute for`)
-    }
-
-    let username = args[0]
-    let time = args.slice(1)
-
-    this.sendMinecraftMessage(`/g mute ${username} ${time}`)
-    message.reply(`${username} has been muted for ${time}`)
+    this.sendMinecraftMessage(`/g mute ${user ? user : ''} ${time ? time : ''}`)
   }
 }
 

--- a/src/discord/commands/PromoteCommand.js
+++ b/src/discord/commands/PromoteCommand.js
@@ -3,15 +3,9 @@ const DiscordCommand = require('../../contracts/DiscordCommand')
 class PromoteCommand extends DiscordCommand {
   onCommand(message) {
     let args = this.getArgs(message)
+    let user = args.shift()
 
-    if (args.length == 0) {
-      message.reply(`You need to specify a user to promote`)
-    }
-
-    let username = args[0]
-
-    this.sendMinecraftMessage(`/g promote ${username}`)
-    message.reply(`${username} has been promoted`)
+    this.sendMinecraftMessage(`/g promote ${user ? user : ''}`)
   }
 }
 

--- a/src/discord/handlers/StateHandler.js
+++ b/src/discord/handlers/StateHandler.js
@@ -15,7 +15,7 @@ class StateHandler {
       channel.send({
         embed: {
           author: { name: `Chat Bridge is Online` },
-          color: '7CFC00'
+          color: '47F049'
         }
       })
     })
@@ -26,7 +26,7 @@ class StateHandler {
       channel.send({
         embed: {
           author: { name: `Chat Bridge is Offline` },
-          color: 'DC143C'
+          color: 'F04947'
         }
       }).then(() => { process.exit() })
     }).catch(process.exit())

--- a/src/minecraft/handlers/ChatHandler.js
+++ b/src/minecraft/handlers/ChatHandler.js
@@ -181,8 +181,6 @@ class StateHandler extends EventHandler {
       return
     }
 
-    console.log(playerMessage)
-
     this.minecraft.broadcastMessage({
       username: username,
       message: playerMessage,

--- a/src/minecraft/handlers/ChatHandler.js
+++ b/src/minecraft/handlers/ChatHandler.js
@@ -156,6 +156,10 @@ class StateHandler extends EventHandler {
       return this.minecraft.broadcastCleanEmbed({ message: message.replace(/\[(.*?)\]/g, ''), color: 'DC143C' })
     }
 
+    if (this.isTooFast(message)) {
+      return this.minecraft.app.log.warn(message)
+    }
+
     if (!this.isGuildMessage(message)) {
       return
     }
@@ -294,6 +298,10 @@ class StateHandler extends EventHandler {
 
   isAlreadyHasRank(message) {
     return message == 'They already have that rank!'
+  }
+
+  isTooFast(message) {
+    return message == 'You are sending commands too fast! Please slow down.'
   }
 }
 

--- a/src/minecraft/handlers/ChatHandler.js
+++ b/src/minecraft/handlers/ChatHandler.js
@@ -152,8 +152,12 @@ class StateHandler extends EventHandler {
       return this.minecraft.broadcastCleanEmbed({ message: `${user} is not in the guild.`, color: 'DC143C' })
     }
 
-    if (this.isLowestRank(message) || this.isAlreadyHasRank(message)) {
-      return this.minecraft.broadcastCleanEmbed({ message: message.replace(/\[(.*?)\]/g, ''), color: 'DC143C' })
+    if (this.isLowestRank(message)) {
+      return this.minecraft.broadcastCleanEmbed({ message: message.replace(/\[(.*?)\]/g, '').trim().split(' ')[0], color: 'DC143C' })
+    }
+
+    if (this.isAlreadyHasRank(message)) {
+      return this.minecraft.broadcastCleanEmbed({ message: `They already have that rank!`, color: 'DC143C' })
     }
 
     if (this.isTooFast(message)) {
@@ -293,7 +297,7 @@ class StateHandler extends EventHandler {
   }
 
   isLowestRank(message) {
-    return message.endsWith("is already the lowest rank you've created!") && !message.includes(':')
+    return message.includes("is already the lowest rank you've created!") && !message.includes(':')
   }
 
   isAlreadyHasRank(message) {

--- a/src/minecraft/handlers/ChatHandler.js
+++ b/src/minecraft/handlers/ChatHandler.js
@@ -221,15 +221,15 @@ class StateHandler extends EventHandler {
   }
 
   isJoinMessage(message) {
-    return message.endsWith('joined the guild!') && !message.includes(':')
+    return message.includes('joined the guild!') && !message.includes(':')
   }
 
   isLeaveMessage(message) {
-    return message.endsWith('left the guild!') && !message.includes(':')
+    return message.includes('left the guild!') && !message.includes(':')
   }
 
   isKickMessage(message) {
-    return message.includes('was kicked from the guild by') && message.endsWith('!') && !message.includes(':')
+    return message.includes('was kicked from the guild by') && !message.includes(':')
   }
 
   isPromotionMessage(message) {
@@ -241,7 +241,7 @@ class StateHandler extends EventHandler {
   }
 
   isBlockedMessage(message) {
-    return message.startsWith('We blocked your comment')
+    return message.includes('We blocked your comment') && message.includes(':')
   }
 
   isRepeatMessage(message) {
@@ -253,19 +253,19 @@ class StateHandler extends EventHandler {
   }
 
   isIncorrectUsage(message) {
-    return message.startsWith('Invalid usage!')
+    return message.includes('Invalid usage!') && message.includes(':')
   }
 
   isOnlineInvite(message) {
-    return message.startsWith('You invited') && message.endsWith('to your guild. They have 5 minutes to accept.')
+    return message.includes('You invited') && message.includes('to your guild. They have 5 minutes to accept.') && message.includes(':')
   }
 
   isOfflineInvite(message) {
-    return message.startsWith('You sent an offline invite to') && message.endsWith('They will have 5 minutes to accept once they come online!')
+    return message.includes('You sent an offline invite to') && message.includes('They will have 5 minutes to accept once they come online!') && !message.includes(':')
   }
 
   isFailedInvite(message) {
-    return (message.endsWith('is already in another guild!') && !message.includes(':')) || message == 'You cannot invite this player to your guild!' || (message.startsWith("You've already invited") && message.endsWith("to your guild! Wait for them to accept!") || message.endsWith('is already in your guild!'))
+    return (message.includes('is already in another guild!') || message.includes('You cannot invite this player to your guild!') || (message.includes("You've already invited") && message.includes("to your guild! Wait for them to accept!")) || message.includes('is already in your guild!')) && !message.includes(':')
   }
 
   isUserMuteMessage(message) {
@@ -281,11 +281,11 @@ class StateHandler extends EventHandler {
   }
 
   isGuildUnmuteMessage(message) {
-    return message.endsWith('has unmuted the guild chat!') && !message.includes(':')
+    return message.includes('has unmuted the guild chat!') && !message.includes(':')
   }
 
   isSetrankFail(message) {
-    return message.startsWith("I couldn't find a rank by the name of ")
+    return message.includes("I couldn't find a rank by the name of ") && !message.includes(':')
   }
 
   isAlreadyMuted(message) {
@@ -293,7 +293,7 @@ class StateHandler extends EventHandler {
   }
 
   isNotInGuild(message) {
-    return message.endsWith(' is not in your guild!') && !message.includes(':')
+    return message.includes(' is not in your guild!') && !message.includes(':')
   }
 
   isLowestRank(message) {

--- a/src/minecraft/handlers/ChatHandler.js
+++ b/src/minecraft/handlers/ChatHandler.js
@@ -164,6 +164,12 @@ class StateHandler extends EventHandler {
       return this.minecraft.app.log.warn(message)
     }
 
+    if (this.isPlayerNotFound(message)) {
+      let user = message.split(' ')[8].slice(1, -1)
+
+      return this.minecraft.broadcastCleanEmbed({ message: `Player \`${user}\` not found.`, color: 'DC143C' })
+    }
+
     if (!this.isGuildMessage(message)) {
       return
     }
@@ -306,6 +312,10 @@ class StateHandler extends EventHandler {
 
   isTooFast(message) {
     return message.includes('You are sending commands too fast! Please slow down.') && !message.includes(':')
+  }
+
+  isPlayerNotFound(message) {
+    return message.startsWith(`Can't find a player by the name of`)
   }
 }
 

--- a/src/minecraft/handlers/ChatHandler.js
+++ b/src/minecraft/handlers/ChatHandler.js
@@ -152,6 +152,10 @@ class StateHandler extends EventHandler {
       return this.minecraft.broadcastCleanEmbed({ message: `${user} is not in the guild.`, color: 'DC143C' })
     }
 
+    if (this.isLowestRank(message) || this.isAlreadyHasRank(message)) {
+      return this.minecraft.broadcastCleanEmbed({ message: message.replace(/\[(.*?)\]/g, ''), color: 'DC143C' })
+    }
+
     if (!this.isGuildMessage(message)) {
       return
     }
@@ -237,7 +241,7 @@ class StateHandler extends EventHandler {
   }
 
   isNoPermission(message) {
-    return message == 'You must be the Guild Master to use that command!' || message == 'You do not have permission to use this command!' || message == "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error." || message == "You cannot mute the guild master!" || message == "You cannot kick this player!" || message == "You can only promote up to your own rank!"
+    return message == 'You must be the Guild Master to use that command!' || message == 'You do not have permission to use this command!' || message == "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error." || message == "You cannot mute the guild master!" || message == "You cannot kick this player!" || message == "You can only promote up to your own rank!" || message == "You cannot mute yourself from the guild!" || (message.endsWith("is the guild master so can't be demoted!") && !message.includes(":")) || (message.endsWith("is the guild master so can't be promoted anymore!") && !message.includes(":"))
   }
 
   isIncorrectUsage(message) {
@@ -281,7 +285,15 @@ class StateHandler extends EventHandler {
   }
 
   isNotInGuild(message) {
-    return message.endsWith(' is not in your guild!')
+    return message.endsWith(' is not in your guild!') && !message.includes(':')
+  }
+
+  isLowestRank(message) {
+    return message.endsWith("is already the lowest rank you've created!") && !message.includes(':')
+  }
+
+  isAlreadyHasRank(message) {
+    return message == 'They already have that rank!'
   }
 }
 

--- a/src/minecraft/handlers/ChatHandler.js
+++ b/src/minecraft/handlers/ChatHandler.js
@@ -245,7 +245,7 @@ class StateHandler extends EventHandler {
   }
 
   isNoPermission(message) {
-    return message == 'You must be the Guild Master to use that command!' || message == 'You do not have permission to use this command!' || message == "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error." || message == "You cannot mute the guild master!" || message == "You cannot kick this player!" || message == "You can only promote up to your own rank!" || message == "You cannot mute yourself from the guild!" || (message.endsWith("is the guild master so can't be demoted!") && !message.includes(":")) || (message.endsWith("is the guild master so can't be promoted anymore!") && !message.includes(":"))
+    return (message.includes('You must be the Guild Master to use that command!') || message.includes('You do not have permission to use this command!') || message.includes("I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error.") || message.includes("You cannot mute a guild member with a higher guild rank!") || message.includes("You cannot kick this player!") || message.includes("You can only promote up to your own rank!") || message.includes("You cannot mute yourself from the guild!") || message.includes("is the guild master so can't be demoted!") || message.includes("is the guild master so can't be promoted anymore!")) && !message.includes(":")
   }
 
   isIncorrectUsage(message) {
@@ -285,7 +285,7 @@ class StateHandler extends EventHandler {
   }
 
   isAlreadyMuted(message) {
-    return message == 'This player is already muted!'
+    return message.includes('This player is already muted!') && !message.includes(':')
   }
 
   isNotInGuild(message) {
@@ -297,11 +297,11 @@ class StateHandler extends EventHandler {
   }
 
   isAlreadyHasRank(message) {
-    return message == 'They already have that rank!'
+    return message.includes('They already have that rank!') && !message.includes(':')
   }
 
   isTooFast(message) {
-    return message == 'You are sending commands too fast! Please slow down.'
+    return message.includes('You are sending commands too fast! Please slow down.') && !message.includes(':')
   }
 }
 

--- a/src/minecraft/handlers/ChatHandler.js
+++ b/src/minecraft/handlers/ChatHandler.js
@@ -249,7 +249,7 @@ class StateHandler extends EventHandler {
   }
 
   isBlockedMessage(message) {
-    return message.includes('We blocked your comment') && message.includes(':')
+    return message.includes('We blocked your comment') && !message.includes(':')
   }
 
   isRepeatMessage(message) {
@@ -261,11 +261,11 @@ class StateHandler extends EventHandler {
   }
 
   isIncorrectUsage(message) {
-    return message.includes('Invalid usage!') && message.includes(':')
+    return message.includes('Invalid usage!') && !message.includes(':')
   }
 
   isOnlineInvite(message) {
-    return message.includes('You invited') && message.includes('to your guild. They have 5 minutes to accept.') && message.includes(':')
+    return message.includes('You invited') && message.includes('to your guild. They have 5 minutes to accept.') && !message.includes(':')
   }
 
   isOfflineInvite(message) {

--- a/src/minecraft/handlers/ChatHandler.js
+++ b/src/minecraft/handlers/ChatHandler.js
@@ -153,7 +153,9 @@ class StateHandler extends EventHandler {
     }
 
     if (this.isLowestRank(message)) {
-      return this.minecraft.broadcastCleanEmbed({ message: message.replace(/\[(.*?)\]/g, '').trim().split(' ')[0], color: 'DC143C' })
+      let user = message.replace(/\[(.*?)\]/g, '').trim().split(' ')[0]
+
+      return this.minecraft.broadcastCleanEmbed({ message: `${user} is already the lowest guild rank!`, color: 'DC143C' })
     }
 
     if (this.isAlreadyHasRank(message)) {

--- a/src/minecraft/handlers/ChatHandler.js
+++ b/src/minecraft/handlers/ChatHandler.js
@@ -25,13 +25,131 @@ class StateHandler extends EventHandler {
     if (this.isLoginMessage(message)) {
       let user = message.split('>')[1].trim().split('joined.')[0].trim()
 
-      return this.minecraft.broadcastLogin(user)
+      return this.minecraft.broadcastPlayerToggle({ username: user, message: `joined.`, color: '47F049' })
     }
 
     if (this.isLogoutMessage(message)) {
       let user = message.split('>')[1].trim().split('left.')[0].trim()
 
-      return this.minecraft.broadcastLogout(user)
+      return this.minecraft.broadcastPlayerToggle({ username: user, message: `left.`, color: 'F04947' })
+    }
+
+    if (this.isJoinMessage(message)) {
+      let user = message.replace(/\[(.*?)\]/g, '').trim().split(/ +/g)[0]
+
+      return this.minecraft.broadcastHeadedEmbed({
+        message: `${user} joined the guild!`,
+        title: `Member Joined`,
+        icon: `https://mc-heads.net/avatar/${user}`,
+        color: '47F049'
+      })
+    }
+
+    if (this.isLeaveMessage(message)) {
+      let user = message.replace(/\[(.*?)\]/g, '').trim().split(/ +/g)[0]
+
+      return this.minecraft.broadcastHeadedEmbed({
+        message: `${user} left the guild!`,
+        title: `Member Left`,
+        icon: `https://mc-heads.net/avatar/${user}`,
+        color: 'F04947'
+      })
+    }
+
+    if (this.isKickMessage(message)) {
+      let user = message.replace(/\[(.*?)\]/g, '').trim().split(/ +/g)[0]
+
+      return this.minecraft.broadcastHeadedEmbed({
+        message: `${user} was kicked from the guild!`,
+        title: `Member Kicked`,
+        icon: `https://mc-heads.net/avatar/${user}`,
+        color: 'F04947'
+      })
+    }
+
+    if (this.isPromotionMessage(message)) {
+      let username = message.replace(/\[(.*?)\]/g, '').trim().split(/ +/g)[0]
+      let newRank = message.replace(/\[(.*?)\]/g, '').trim().split(' to ').pop().trim()
+
+      return this.minecraft.broadcastCleanEmbed({ message: `${username} was promoted to ${newRank}`, color: '47F049' })
+    }
+
+    if (this.isDemotionMessage(message)) {
+      let username = message.replace(/\[(.*?)\]/g, '').trim().split(/ +/g)[0]
+      let newRank = message.replace(/\[(.*?)\]/g, '').trim().split(' to ').pop().trim()
+
+      return this.minecraft.broadcastCleanEmbed({ message: `${username} was demoted to ${newRank}`, color: 'F04947' })
+    }
+
+    if (this.isBlockedMessage(message)) {
+      let blockedMsg = message.match(/".+"/g)[0].slice(1, -1)
+
+      return this.minecraft.broadcastCleanEmbed({ message: `Message \`${blockedMsg}\` blocked by Hypixel.`, color: 'DC143C' })
+    }
+
+    if (this.isRepeatMessage(message)) {
+      return this.minecraft.broadcastCleanEmbed({ message: `You cannot say the same message twice!`, color: 'DC143C' })
+    }
+
+    if (this.isNoPermission(message)) {
+      return this.minecraft.broadcastCleanEmbed({ message: `I don't have permission to do that!`, color: 'DC143C' })
+    }
+
+    if (this.isIncorrectUsage(message)) {
+      return this.minecraft.broadcastCleanEmbed({ message: message.split("'").join("`"), color: 'DC143C' })
+    }
+
+    if (this.isOnlineInvite(message)) {
+      let user = message.replace(/\[(.*?)\]/g, '').trim().split(/ +/g)[2]
+
+      return this.minecraft.broadcastCleanEmbed({ message: `${user} was invited to the guild!`, color: '47F049' })
+    }
+
+    if (this.isOfflineInvite(message)) {
+      let user = message.replace(/\[(.*?)\]/g, '').trim().split(/ +/g)[6].match(/\w+/g)[0]
+
+      return this.minecraft.broadcastCleanEmbed({ message: `${user} was offline invited to the guild!`, color: '47F049' })
+    }
+
+    if (this.isFailedInvite(message)) {
+      return this.minecraft.broadcastCleanEmbed({ message: message.replace(/\[(.*?)\]/g, '').trim(), color: 'DC143C' })
+    }
+
+    if (this.isGuildMuteMessage(message)) {
+      let time = message.replace(/\[(.*?)\]/g, '').trim().split(/ +/g)[7]
+
+      return this.minecraft.broadcastCleanEmbed({ message: `Guild Chat has been muted for ${time}`, color: 'F04947' })
+    }
+
+    if (this.isGuildUnmuteMessage(message)) {
+      return this.minecraft.broadcastCleanEmbed({ message: `Guild Chat has been unmuted!`, color: '47F049' })
+    }
+
+    if (this.isUserMuteMessage(message)) {
+      let user = message.replace(/\[(.*?)\]/g, '').trim().split(/ +/g)[3].replace(/[^\w]+/g, '')
+      let time = message.replace(/\[(.*?)\]/g, '').trim().split(/ +/g)[5]
+
+      return this.minecraft.broadcastCleanEmbed({ message: `${user} has been muted for ${time}`, color: 'F04947' })
+    }
+
+    if (this.isUserUnmuteMessage(message)) {
+      let user = message.replace(/\[(.*?)\]/g, '').trim().split(/ +/g)[3]
+
+      return this.minecraft.broadcastCleanEmbed({ message: `${user} has been unmuted!`, color: '47F049' })
+    }
+
+    if (this.isSetrankFail(message)) {
+      return this.minecraft.broadcastCleanEmbed({ message: `Rank not found.`, color: 'DC143C' })
+    }
+
+    if (this.isAlreadyMuted(message)) {
+      return this.minecraft.broadcastCleanEmbed({ message: `This user is already muted!`, color: 'DC143C' })
+    }
+
+    if (this.isNotInGuild(message)) {
+      let user = message.replace(/\[(.*?)\]/g, '').trim().split(' ')[0]
+
+      return this.minecraft.broadcastCleanEmbed({ message: `${user} is not in the guild.`, color: 'DC143C' })
     }
 
     if (!this.isGuildMessage(message)) {
@@ -90,6 +208,82 @@ class StateHandler extends EventHandler {
 
   isLogoutMessage(message) {
     return message.startsWith('Guild >') && message.endsWith('left.') && !message.includes(':')
+  }
+
+  isJoinMessage(message) {
+    return message.endsWith('joined the guild!') && !message.includes(':')
+  }
+
+  isLeaveMessage(message) {
+    return message.endsWith('left the guild!') && !message.includes(':')
+  }
+
+  isKickMessage(message) {
+    return message.includes('was kicked from the guild by') && message.endsWith('!') && !message.includes(':')
+  }
+
+  isPromotionMessage(message) {
+    return message.includes('was promoted from') && !message.includes(':')
+  }
+
+  isDemotionMessage(message) {
+    return message.includes('was demoted from') && !message.includes(':')
+  }
+
+  isBlockedMessage(message) {
+    return message.startsWith('We blocked your comment')
+  }
+
+  isRepeatMessage(message) {
+    return message == 'You cannot say the same message twice!'
+  }
+
+  isNoPermission(message) {
+    return message == 'You must be the Guild Master to use that command!' || message == 'You do not have permission to use this command!' || message == "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error." || message == "You cannot mute the guild master!" || message == "You cannot kick this player!" || message == "You can only promote up to your own rank!"
+  }
+
+  isIncorrectUsage(message) {
+    return message.startsWith('Invalid usage!')
+  }
+
+  isOnlineInvite(message) {
+    return message.startsWith('You invited') && message.endsWith('to your guild. They have 5 minutes to accept.')
+  }
+
+  isOfflineInvite(message) {
+    return message.startsWith('You sent an offline invite to') && message.endsWith('They will have 5 minutes to accept once they come online!')
+  }
+
+  isFailedInvite(message) {
+    return (message.endsWith('is already in another guild!') && !message.includes(':')) || message == 'You cannot invite this player to your guild!' || (message.startsWith("You've already invited") && message.endsWith("to your guild! Wait for them to accept!") || message.endsWith('is already in your guild!'))
+  }
+
+  isUserMuteMessage(message) {
+    return message.includes('has muted') && message.includes('for') && !message.includes(':')
+  }
+
+  isUserUnmuteMessage(message) {
+    return message.includes('has unmuted') && !message.includes(':')
+  }
+
+  isGuildMuteMessage(message) {
+    return message.includes('has muted the guild chat for') && !message.includes(':')
+  }
+
+  isGuildUnmuteMessage(message) {
+    return message.endsWith('has unmuted the guild chat!') && !message.includes(':')
+  }
+
+  isSetrankFail(message) {
+    return message.startsWith("I couldn't find a rank by the name of ")
+  }
+
+  isAlreadyMuted(message) {
+    return message == 'This player is already muted!'
+  }
+
+  isNotInGuild(message) {
+    return message.endsWith(' is not in your guild!')
   }
 }
 


### PR DESCRIPTION
Added broadcasts for all the following guild events:
- Player logins and logouts
- Guild joins, leaves and kicks
- Guild rank promotions and demotions
- Hypixel error messages (`You cannot say the same message twice`, `We blocked your comment...`, `You do not have permission to use this command!` etc)
- Online and offline guild invite feedback
- User and guild chat mutes and unmutes
---
All the broadcasts are sent in the regular guild chat channel as that's the only place commands work and are roughly colour coded on if they're positive or negative. Command feedback built into the bot has also been removed, instead it relies on Hypixel's `Invalid usage!` feedback as shown below.  

![omg leaking guild chat D:](https://user-images.githubusercontent.com/71194294/121440211-622bcf80-c97f-11eb-947a-3ff42f142d0d.png)
![oh noe more top secret leaks](https://user-images.githubusercontent.com/71194294/121441212-445f6a00-c981-11eb-960e-eca0d8644d35.png)

Thanks to PR #22 for reminding me I'd started this :)