### PR TITLE
Fix Chat Bridge is Offline message not sending

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hypixel-discord-chat-bridge",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A Hypixel guild chat and Discord chat bridge",
   "main": "index.js",
   "scripts": {

--- a/src/discord/handlers/StateHandler.js
+++ b/src/discord/handlers/StateHandler.js
@@ -29,7 +29,7 @@ class StateHandler {
           color: 'F04947'
         }
       }).then(() => { process.exit() })
-    }).catch(process.exit())
+    }).catch(() => { process.exit() })
   }
 }
 


### PR DESCRIPTION
Something was causing the bridge to not send the `Chat Bridge is Offline` message upon exiting or being restarted - this fixes that issue and makes it send when needed.