### PR TITLE
Add lobbyHolder option to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       SERVER_PORT: 25565
       MINECRAFT_USERNAME: yourUsername
       MINECRAFT_PASSWORD: yourPassword
+      MINECRAFT_LOBBY_HOLDER: lobbyHolder
       MINECRAFT_ACCOUNT_TYPE: mojang
       DISCORD_TOKEN: yourDiscordToken
       DISCORD_CHANNEL: discordChannelId


### PR DESCRIPTION
Fairly self-explanatory, the option is in `Configuration.js` and `config.example.json` but not `docker-compose.yml`.

@Senither I think you know more about the bot that's used as the lobby holder so if you could update the readme with more info about it I think that would help avoid confusion :)